### PR TITLE
feat: enhance langfuse example with follow-up request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ base64 = "0.22.1"
 [dev-dependencies]
 # For examples and tests
 dotenv = "0.15"
+chrono = "0.4"
 tokio = { version = "1.47", features = ["rt-multi-thread", "macros", "time"] }
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio", "trace"] }
 opentelemetry-otlp = { version = "0.27", features = ["tokio", "http-proto", "reqwest-client"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ tokio = { version = "1.47", features = ["rt-multi-thread", "macros", "time"] }
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio", "trace"] }
 opentelemetry-otlp = { version = "0.27", features = ["tokio", "http-proto", "reqwest-client"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.27"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ opentelemetry_sdk = { version = "0.27", features = ["rt-tokio", "trace"] }
 opentelemetry-otlp = { version = "0.27", features = ["tokio", "http-proto", "reqwest-client"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.27"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
 
 [[example]]
 name = "basic"

--- a/examples/with_langfuse.rs
+++ b/examples/with_langfuse.rs
@@ -76,9 +76,9 @@ async fn run_conversation(client: &Client<AzureConfig>) -> Result<(), Box<dyn Er
     // Set the session ID in Langfuse context
     use reqwest_openai_tracing::langfuse_context;
     langfuse_context::set_session_id(&session_id);
-    
+
     // Create an OpenTelemetry span using the macro-style approach
-    use opentelemetry::trace::{Tracer, TraceContextExt};
+    use opentelemetry::trace::{TraceContextExt, Tracer};
     let tracer = global::tracer("conversation-tracer");
     let span = tracer
         .span_builder("run_conversation")


### PR DESCRIPTION
## Summary

Enhanced the `with_langfuse` example to demonstrate multi-turn conversation tracing with proper span hierarchy and dynamic session management.

## Changes

### Multi-turn Conversation Support
- Added a second API request that includes conversation history
- The follow-up request asks to translate the initial response to French
- Demonstrates how the middleware tracks multiple requests within the same session
- Shows token usage for both requests (including increased prompt tokens due to conversation history)

### Refactored Code Structure
- Extracted conversation logic into a dedicated `run_conversation` method
- Improved code organization and reusability

### Custom OpenTelemetry Span with Proper Hierarchy
- Added a parent span `run_conversation` that wraps both OpenAI calls
- Fixed context propagation using `Context::attach()` to ensure child spans are properly nested
- Includes conversation metadata as span attributes:
  - `conversation.session_id`: Dynamically generated timestamp-based ID
  - `conversation.type`: "translation_request"
  - `conversation.turns`: 2
  - `conversation.topic": "France capital"
- Creates proper span hierarchy: conversation span → OpenAI-generation spans → individual API call spans

### Dynamic Session Management
- Generates unique session ID from current timestamp (format: YYYYMMDDHHMMSS)
- Sets session ID in both Langfuse context and span attributes
- Enables tracking of related requests across a conversation

## Dependencies

- Added `chrono = "0.4"` as a dev dependency for timestamp formatting
- Removed unused `tracing-opentelemetry` dependency

## Testing

Tested locally:
- ✅ `cargo fmt` - all code is properly formatted
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` - no warnings
- ✅ `cargo test --all-features -- --test-threads=1` - all tests pass
- ✅ Ran the example and verified in Langfuse cloud:
  - Dynamic session ID generation works correctly
  - Both traces appear under the parent `run_conversation` span
  - Span hierarchy is properly created and visible
  - Custom conversation attributes are recorded and visible in the trace
  - Conversation metadata is included in traces

## Example Output

```
Starting conversation with session_id: 20250822225133

First response: The capital of France is **Paris**.
Token usage - Prompt: 14, Completion: 10, Total: 24

Follow-up response (in French): La capitale de la France est **Paris**.
Follow-up token usage - Prompt: 41, Completion: 11, Total: 52
```

The increased prompt tokens (41 vs 14) in the follow-up request demonstrate that the conversation history is properly included.

## Verified Tracing Hierarchy in Langfuse

The example creates the following span hierarchy in Langfuse:
```
run_conversation (1.19s total)
├── OpenAI chat.completions (0.60s, 14→10 tokens)
└── OpenAI chat.completions (0.58s, 41→11 tokens)
```

Custom attributes visible in the trace:
- `conversation.session_id`: "20250822225133"
- `conversation.type": "translation_request"
- `conversation.turns`: 2
- `conversation.topic": "France capital"
- `session.id`: "20250822225133"
- `user.id": "example-user-456"
- `langfuse.trace.tags`: ["example", "langfuse"]