### PR TITLE
fix: configure release-plz to work without crates.io

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,4 +25,4 @@ jobs:
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # No CARGO_REGISTRY_TOKEN needed since we're not publishing to crates.io

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,6 +9,9 @@ git_release_enable = true
 git_release_name = "v{{version}}"
 # Update dependencies during release
 dependencies_update = true
+# Disable registry operations for local packages
+publish_allow_dirty = true
+pr_labels = ["release"]
 
 [[package]]
 name = "reqwest-openai-tracing"


### PR DESCRIPTION
## Summary

This PR fixes the release-plz workflow failure that occurs when trying to check for the latest version on crates.io.

## Problem

The release-plz workflow was failing with:
```
failed to read the latest version of `reqwest-openai-tracing` from the cargo registry
```

This happens because:
1. We can't publish to crates.io due to the git dependency on async-openai
2. release-plz was trying to check crates.io for the latest version to determine if a new release is needed

## Solution

1. **Remove CARGO_REGISTRY_TOKEN** from the workflow since we're not publishing to crates.io
2. **Add `publish_allow_dirty = true`** to the workspace configuration to allow releases without registry checks
3. **Keep `publish = false`** for the package to prevent any accidental publishing attempts

## Changes

- Updated `release-plz.toml` to work without crates.io registry checks
- Removed unnecessary CARGO_REGISTRY_TOKEN from the workflow
- Added comment explaining why the token is not needed

## Testing

After merging, the release-plz workflow should:
1. Create release PRs based on conventional commits
2. Create GitHub releases with tags when PRs are merged
3. Not attempt to publish to crates.io or check the registry for versions

## Related Issue

Fixes the workflow failure seen at: https://github.com/timvw/reqwest-openai-tracing/actions/runs/17166850993