### PR TITLE
perf: use faster binary installation for release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -39,7 +39,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       
       - name: Install release-plz
-        run: cargo install release-plz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: release-plz
       
       - name: Run release-plz
         run: |


### PR DESCRIPTION
## Summary
- Optimize release-plz installation in CI workflow

## Problem
The workflow was using `cargo install release-plz` which compiles from source and can take 7+ minutes, sometimes causing timeouts.

## Solution
Use `taiki-e/install-action` to download and install a pre-built binary of release-plz. This reduces installation time from ~7 minutes to a few seconds.

## Test plan
- [ ] Verify workflow runs successfully with the new installation method
- [ ] Check that release-plz functions correctly